### PR TITLE
feat(codec): Primitive type codec support for yomo

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -1,0 +1,308 @@
+package y3
+
+import (
+	"encoding/hex"
+	"io"
+	"strings"
+
+	"github.com/yomorun/yomo-codec-golang/internal/utils"
+
+	ycodec "github.com/yomorun/yomo-codec-golang/internal/codec"
+	encoding "github.com/yomorun/yomo-codec-golang/pkg"
+)
+
+var (
+	placeholder = []byte{0, 1, 2, 3}
+	logger      = utils.Logger.WithPrefix(utils.DefaultLogger, "Codec")
+)
+
+type Codec struct {
+	Value []byte
+
+	Tag *ycodec.Tag
+
+	LengthBuf []byte
+	Length    int32
+	Size      int32
+
+	Observe string
+	Sbuf    []byte
+
+	Result       [][]byte
+	OriginResult [][]byte
+}
+
+func NewCodec(observe string) *Codec {
+	codec := &Codec{
+		Value:        make([]byte, 0),
+		Tag:          nil,
+		LengthBuf:    make([]byte, 0),
+		Length:       0,
+		Size:         0,
+		Sbuf:         make([]byte, 0),
+		Observe:      observe,
+		Result:       make([][]byte, 0),
+		OriginResult: make([][]byte, 0),
+	}
+
+	return codec
+}
+
+func (codec *Codec) Decoder(buf []byte) {
+	key := keyOf(codec.Observe)
+	for _, c := range buf {
+		// tag
+		if codec.Tag == nil {
+			codec.Tag = ycodec.NewTag(c)
+			codec.Sbuf = append(codec.Sbuf, c)
+			continue
+		}
+
+		// length
+		if codec.Size == 0 {
+			codec.LengthBuf = append(codec.LengthBuf, c)
+			codec.Sbuf = append(codec.Sbuf, c)
+			length, size, err := decodeLength(codec.LengthBuf)
+			if err != nil {
+				continue
+			}
+			codec.Length = length
+			codec.Size = size
+			continue
+		}
+
+		codec.Sbuf = append(codec.Sbuf, c)
+
+		// buf end, then handle Sbuf
+		if int32(len(codec.Sbuf)) == 1+codec.Size+codec.Length {
+			// Decode Packet from Sbuf
+			packet, _, err := DecodeNodePacket(codec.Sbuf)
+			if err != nil {
+				logger.Errorf("::Decoder DecodeNodePacket error:%v", err)
+				codec.reset()
+				continue
+			}
+
+			// temp save Sbuf and reset
+			result := make([]byte, 0)
+			originResult := codec.Sbuf
+			codec.reset()
+
+			//matching
+			var matching = false
+			flag, _, _ := matchingKey(key, packet)
+			if flag || []byte("*")[0] == key {
+				matching = true
+				result = originResult
+			}
+
+			// save to result
+			if matching {
+				codec.Result = append(codec.Result, result)
+				codec.OriginResult = append(codec.OriginResult, placeholder)
+			} else {
+				codec.OriginResult = append(codec.OriginResult, originResult)
+			}
+
+		}
+	}
+}
+
+func (codec *Codec) reset() {
+	codec.Tag = nil
+	codec.LengthBuf = make([]byte, 0)
+	codec.Length = 0
+	codec.Size = 0
+	codec.Sbuf = make([]byte, 0)
+}
+
+func matchingKey(key byte, node *NodePacket) (flag bool, isNode bool, packet interface{}) {
+	if len(node.PrimitivePackets) > 0 {
+		for _, p := range node.PrimitivePackets {
+			if key == p.tag.SeqID() {
+				return true, false, p
+			}
+		}
+	}
+
+	if len(node.NodePackets) > 0 {
+		for _, n := range node.NodePackets {
+			if key == n.tag.SeqID() {
+				return true, true, n
+			}
+			//return matchingKey(key, &n)
+			flag, isNode, packet = matchingKey(key, &n)
+			if flag {
+				return
+			}
+		}
+	}
+
+	return false, false, nil
+}
+
+func keyOf(hexStr string) byte {
+	if strings.HasPrefix(hexStr, "0x") {
+		hexStr = strings.TrimPrefix(hexStr, "0x")
+	} else if strings.HasPrefix(hexStr, "0X") {
+		hexStr = strings.TrimPrefix(hexStr, "0X")
+	}
+
+	data, err := hex.DecodeString(hexStr)
+	if err != nil {
+		logger.Errorf("hex.DecodeString error: %v", err)
+		return 0xff
+	}
+
+	if len(data) == 0 {
+		logger.Errorf("hex.DecodeString data is []")
+		return 0xff
+	}
+
+	return data[0]
+}
+
+func decodeLength(buf []byte) (length int32, size int32, err error) {
+	varCodec := encoding.VarCodec{}
+	err = varCodec.DecodePVarInt32(buf, &length)
+	size = int32(varCodec.Size)
+	return
+}
+
+func (codec *Codec) Read(mold interface{}) (interface{}, error) {
+	if len(codec.Result) == 0 {
+		return nil, nil
+	}
+
+	result := codec.Result[0]
+	codec.Result = codec.Result[1:]
+
+	// take value from node
+	err := codec.Unmarshal(result, &mold)
+	if err != nil {
+		return nil, err
+	}
+
+	// for Encoder::merge
+	codec.Value = result
+
+	return mold, nil
+}
+
+func (codec *Codec) Write(w io.Writer, T interface{}, mold interface{}) (int, error) {
+	// #1. mold --> NodePacket
+	// #2. merge NodePacket --> codec.Value NodePacket
+	// #3. NodePacket --> []byte
+	// #4. Write []byte
+
+	buf, err := codec.Marshal(T)
+	if err != nil {
+		logger.Errorf("Write::Marshal error:%v", err)
+		return 0, err
+	}
+
+	data, err := codec.Encoder(buf, mold)
+	if err != nil {
+		return 0, err
+	}
+
+	return w.Write(data)
+}
+
+func (codec *Codec) Encoder(buf []byte, mold interface{}) ([]byte, error) {
+	result := make([]byte, 0)
+	index := 0
+	for _, data := range codec.OriginResult {
+		index = index + 1
+		if isDecoder(data) {
+			source, _, _ := DecodeNodePacket(codec.Value)
+
+			key := keyOf(codec.Observe)
+			_buf, err := mergePacket(source, key, buf, mold)
+			if err != nil {
+				return nil, err
+			}
+
+			codec.Value = make([]byte, 0)
+			result = append(result, _buf...)
+			break
+		} else {
+			result = append(result, data...)
+		}
+	}
+
+	codec.OriginResult = codec.OriginResult[index:]
+
+	return result, nil
+}
+
+func mergePacket(source *NodePacket, key byte, value []byte, mold interface{}) ([]byte, error) {
+	np := copyPacket(nil, source, key, value)
+	buf := np.Encode()
+	return buf, nil
+}
+
+func copyPacket(root *NodePacketEncoder, source *NodePacket, key byte, value []byte) *NodePacketEncoder {
+	if root == nil {
+		root = NewNodePacketEncoder(int(source.tag.SeqID()))
+	}
+
+	if len(source.PrimitivePackets) > 0 {
+		for _, p := range source.PrimitivePackets {
+			temp := NewPrimitivePacketEncoder(int(p.tag.SeqID()))
+			if p.tag.SeqID() == key {
+				temp.SetBytes(value)
+			} else {
+				temp.SetBytes(p.ToBytes())
+			}
+
+			root.AddPrimitivePacket(temp)
+		}
+	}
+
+	if len(source.NodePackets) > 0 {
+		for _, n := range source.NodePackets {
+			var temp *NodePacketEncoder
+			if n.IsArray() {
+				temp = NewNodeArrayPacketEncoder(int(n.SeqID()))
+			} else {
+				temp = NewNodePacketEncoder(int(n.SeqID()))
+			}
+
+			if n.tag.SeqID() == key {
+				// replace node
+				temp.AddBytes(value)
+				root.AddNodePacket(temp)
+				continue
+			}
+			np := copyPacket(temp, &n, key, value)
+			root.AddNodePacket(np)
+		}
+	}
+
+	return root
+}
+
+func (codec *Codec) Refresh(w io.Writer) (int, error) {
+	if len(codec.OriginResult) == 0 {
+		return 0, nil
+	}
+	originResult := codec.OriginResult[0]
+	if !isDecoder(originResult) {
+		codec.OriginResult = codec.OriginResult[1:]
+		return w.Write(originResult)
+	}
+	return 0, nil
+}
+
+func isDecoder(buf []byte) bool {
+	if len(buf) != len(placeholder) {
+		return false
+	}
+	for i, v := range placeholder {
+		if buf[i] != v {
+			return false
+		}
+	}
+	return true
+}

--- a/codec_marshal.go
+++ b/codec_marshal.go
@@ -1,0 +1,201 @@
+package y3
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+
+	"github.com/yomorun/yomo-codec-golang/internal/utils"
+
+	encoding "github.com/yomorun/yomo-codec-golang/pkg"
+)
+
+// interface to []byte, serialization
+func (codec *Codec) Marshal(T interface{}) (buf []byte, err error) {
+	//fmt.Printf("#74 reflect.ValueOf(T)=%v\n", reflect.ValueOf(T))
+	switch reflect.ValueOf(T).Kind() {
+	case reflect.String:
+		buf, err = marshalString(T)
+	case reflect.Int32:
+		buf, err = marshalInt32(T)
+	case reflect.Uint32:
+		buf, err = marshalUint32(T)
+	case reflect.Int64:
+		buf, err = marshalInt64(T)
+	case reflect.Uint64:
+		buf, err = marshalUint64(T)
+	case reflect.Float32:
+		buf, err = marshalFloat32(T)
+	case reflect.Float64:
+		buf, err = marshalFloat64(T)
+	case reflect.Array, reflect.Slice:
+		if reflect.ValueOf(T).Len() == 0 {
+			break
+		}
+		switch reflect.ValueOf(T).Index(0).Elem().Kind() {
+		case reflect.String:
+			buf = marshalStringSlice(codec.Observe, T)
+		case reflect.Int32:
+			buf = marshalInt32Slice(codec.Observe, T)
+		case reflect.Uint32:
+			buf = marshalUint32Slice(codec.Observe, T)
+		case reflect.Int64:
+			buf = marshalInt64Slice(codec.Observe, T)
+		case reflect.Uint64:
+			buf = marshalUint64Slice(codec.Observe, T)
+		case reflect.Float32:
+			buf = marshalFloat32Slice(codec.Observe, T)
+		case reflect.Float64:
+			buf = marshalFloat64Slice(codec.Observe, T)
+		default:
+			panic(errors.New("::Marshal error: no matching type in Slice"))
+		}
+	default:
+		panic(errors.New("::Marshal error: no matching type"))
+	}
+
+	return buf, err
+}
+
+func marshalString(T interface{}) (buf []byte, err error) {
+	return []byte(fmt.Sprintf("%v", T)), nil
+}
+
+func marshalInt32(T interface{}) (buf []byte, err error) {
+	size := encoding.SizeOfPVarInt32(T.(int32))
+	codec := encoding.VarCodec{Size: size}
+	buf = make([]byte, size)
+	err = codec.EncodePVarInt32(buf, T.(int32))
+	return buf, err
+}
+
+func marshalUint32(T interface{}) (buf []byte, err error) {
+	size := encoding.SizeOfPVarUInt32(T.(uint32))
+	codec := encoding.VarCodec{Size: size}
+	buf = make([]byte, size)
+	err = codec.EncodePVarUInt32(buf, T.(uint32))
+	return buf, err
+}
+
+func marshalInt64(T interface{}) (buf []byte, err error) {
+	size := encoding.SizeOfPVarInt64(T.(int64))
+	codec := encoding.VarCodec{Size: size}
+	buf = make([]byte, size)
+	err = codec.EncodePVarInt64(buf, T.(int64))
+	return buf, err
+}
+
+func marshalUint64(T interface{}) (buf []byte, err error) {
+	size := encoding.SizeOfPVarUInt64(T.(uint64))
+	codec := encoding.VarCodec{Size: size}
+	buf = make([]byte, size)
+	err = codec.EncodePVarUInt64(buf, T.(uint64))
+	return buf, err
+}
+
+func marshalFloat32(T interface{}) (buf []byte, err error) {
+	size := encoding.SizeOfVarFloat32(T.(float32))
+	codec := encoding.VarCodec{Size: size}
+	buf = make([]byte, size)
+	err = codec.EncodeVarFloat32(buf, T.(float32))
+	return buf, err
+}
+
+func marshalFloat64(T interface{}) (buf []byte, err error) {
+	size := encoding.SizeOfVarFloat64(T.(float64))
+	codec := encoding.VarCodec{Size: size}
+	buf = make([]byte, size)
+	err = codec.EncodeVarFloat64(buf, T.(float64))
+	return buf, err
+}
+
+func marshalStringSlice(observe string, T interface{}) []byte {
+	key := keyOf(observe)
+	var node = NewNodeArrayPacketEncoder(int(key))
+	if out, ok := utils.ToStringSliceArray(T); ok {
+		for _, v := range out {
+			var item = NewPrimitivePacketEncoder(utils.KeyOfArrayItem)
+			item.SetStringValue(fmt.Sprintf("%v", v))
+			node.AddPrimitivePacket(item)
+		}
+	}
+	return node.valbuf
+}
+
+func marshalInt32Slice(observe string, T interface{}) []byte {
+	key := keyOf(observe)
+	var node = NewNodeArrayPacketEncoder(int(key))
+	if out, ok := utils.ToInt64SliceArray(T); ok {
+		for _, v := range out {
+			var item = NewPrimitivePacketEncoder(utils.KeyOfArrayItem)
+			item.SetInt32Value(int32(v.(int64)))
+			node.AddPrimitivePacket(item)
+		}
+	}
+	return node.valbuf
+}
+
+func marshalUint32Slice(observe string, T interface{}) []byte {
+	key := keyOf(observe)
+	var node = NewNodeArrayPacketEncoder(int(key))
+	if out, ok := utils.ToUInt64SliceArray(T); ok {
+		for _, v := range out {
+			var item = NewPrimitivePacketEncoder(utils.KeyOfArrayItem)
+			item.SetUInt32Value(uint32(v.(uint64)))
+			node.AddPrimitivePacket(item)
+		}
+	}
+	return node.valbuf
+}
+
+func marshalInt64Slice(observe string, T interface{}) []byte {
+	key := keyOf(observe)
+	var node = NewNodeArrayPacketEncoder(int(key))
+	if out, ok := utils.ToInt64SliceArray(T); ok {
+		for _, v := range out {
+			var item = NewPrimitivePacketEncoder(utils.KeyOfArrayItem)
+			item.SetInt64Value(v.(int64))
+			node.AddPrimitivePacket(item)
+		}
+	}
+	return node.valbuf
+}
+
+func marshalUint64Slice(observe string, T interface{}) []byte {
+	key := keyOf(observe)
+	var node = NewNodeArrayPacketEncoder(int(key))
+	if out, ok := utils.ToUInt64SliceArray(T); ok {
+		for _, v := range out {
+			var item = NewPrimitivePacketEncoder(utils.KeyOfArrayItem)
+			item.SetUInt64Value(v.(uint64))
+			node.AddPrimitivePacket(item)
+		}
+	}
+	return node.valbuf
+}
+
+func marshalFloat32Slice(observe string, T interface{}) []byte {
+	key := keyOf(observe)
+	var node = NewNodeArrayPacketEncoder(int(key))
+	if out, ok := utils.ToUFloat64SliceArray(T); ok {
+		for _, v := range out {
+			var item = NewPrimitivePacketEncoder(utils.KeyOfArrayItem)
+			item.SetFloat32Value(float32(v.(float64)))
+			node.AddPrimitivePacket(item)
+		}
+	}
+	return node.valbuf
+}
+
+func marshalFloat64Slice(observe string, T interface{}) []byte {
+	key := keyOf(observe)
+	var node = NewNodeArrayPacketEncoder(int(key))
+	if out, ok := utils.ToUFloat64SliceArray(T); ok {
+		for _, v := range out {
+			var item = NewPrimitivePacketEncoder(utils.KeyOfArrayItem)
+			item.SetFloat64Value(v.(float64))
+			node.AddPrimitivePacket(item)
+		}
+	}
+	return node.valbuf
+}

--- a/codec_marshal_test.go
+++ b/codec_marshal_test.go
@@ -1,0 +1,41 @@
+package y3
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMarshal(t *testing.T) {
+	testMarshalPrimitiveType(t, []byte{0x79, 0x2d, 0x6e, 0x65, 0x77}, "y-new")
+	testMarshalPrimitiveType(t, []byte{0x02}, int32(2))
+	testMarshalPrimitiveType(t, []byte{0x02}, uint32(2))
+	testMarshalPrimitiveType(t, []byte{0x0}, int64(0))
+	testMarshalPrimitiveType(t, []byte{0x02}, uint64(2))
+	testMarshalPrimitiveType(t, []byte{0x3e, 0xc0}, float32(0.375))
+	testMarshalPrimitiveType(t, []byte{0x40, 0x37}, float64(23))
+
+	testMarshalPrimitiveTypeArray(t, []byte{0x0, 0x1, 0x61, 0x0, 0x1, 0x62, 0x0, 0x1, 0x63}, "a", "b", "c")
+	testMarshalPrimitiveTypeArray(t, []byte{0x0, 0x1, 0x1, 0x0, 0x1, 0x2, 0x0, 0x1, 0x7f}, int32(1), int32(2), int32(-1))
+	testMarshalPrimitiveTypeArray(t, []byte{0x0, 0x1, 0x1, 0x0, 0x1, 0x2, 0x0, 0x1, 0x3}, uint32(1), uint32(2), uint32(3))
+	testMarshalPrimitiveTypeArray(t, []byte{0x0, 0x1, 0x1, 0x0, 0x1, 0x2, 0x0, 0x1, 0x7f}, int64(1), int64(2), int64(-1))
+	testMarshalPrimitiveTypeArray(t, []byte{0x0, 0x1, 0x1, 0x0, 0x1, 0x2, 0x0, 0x1, 0x3}, uint64(1), uint64(2), uint64(3))
+	testMarshalPrimitiveTypeArray(t, []byte{0x0, 0x2, 0x3e, 0x80, 0x0, 0x2, 0x3e, 0xc0}, float32(0.25), float32(0.375))
+	testMarshalPrimitiveTypeArray(t, []byte{0x0, 0x2, 0x3f, 0xf0, 0x0, 0x1, 0xc0}, float64(1), float64(-2))
+}
+
+func testMarshalPrimitiveType(t *testing.T, expected []byte, T interface{}) {
+	var msg = fmt.Sprintf("testing %v, (%v)", expected, T)
+	codec := NewCodec("")
+	buf, _ := codec.Marshal(T)
+	assert.True(t, bytes.Equal(expected, buf), msg)
+}
+
+func testMarshalPrimitiveTypeArray(t *testing.T, expected []byte, T ...interface{}) {
+	var msg = fmt.Sprintf("testing %v, (%v)", expected, T)
+	codec := NewCodec("")
+	buf, _ := codec.Marshal(T)
+	assert.True(t, bytes.Equal(expected, buf), msg)
+}

--- a/codec_printer.go
+++ b/codec_printer.go
@@ -1,0 +1,73 @@
+package y3
+
+import (
+	"fmt"
+	"io"
+	"time"
+)
+
+func PrintNodePacket(node *NodePacket) {
+	printNodeFormat(node, " %#X=%v ", false, true)
+}
+
+func printNodeFormat(node *NodePacket, format string, isArray bool, isRoot bool) {
+	if isRoot {
+		fmt.Printf("%#x:{ ", node.SeqID())
+	}
+
+	if len(node.NodePackets) > 0 {
+		for _, n := range node.NodePackets {
+			if n.IsArray() {
+				fmt.Printf(" %#x:[ ", n.SeqID())
+				printNodeFormat(&n, format, true, false)
+				fmt.Printf(" ]")
+				continue
+			}
+
+			if n.SeqID() == 0x00 {
+				fmt.Printf(" { ")
+			} else {
+				fmt.Printf(" %#x:{ ", n.SeqID())
+			}
+			printNodeFormat(&n, format, false, false)
+			fmt.Printf(" }")
+
+		}
+	}
+	if len(node.PrimitivePackets) > 0 {
+		for _, p := range node.PrimitivePackets {
+			if isArray {
+				fmt.Printf(" %#x ", p.valbuf)
+			} else {
+				fmt.Printf(format, p.SeqID(), fmt.Sprintf("%#x", p.valbuf))
+			}
+		}
+	}
+
+	if isRoot {
+		fmt.Printf(" }")
+	}
+}
+
+type FmtOut struct{ io.Writer }
+
+func (w FmtOut) Write(buf []byte) (int, error) {
+	fmt.Printf("FmtOut: %s\n", FormatBytes(buf)) // debug:
+	res, _, _ := DecodeNodePacket(buf)
+	fmt.Printf("%v:\t", time.Now().Format("2006-01-02 15:04:05")) // debug:
+	PrintNodePacket(res)
+	fmt.Println()
+	return 0, nil
+}
+
+func FormatBytes(buf []byte) string {
+	var str = ""
+	for i, c := range buf {
+		if i == 0 {
+			str = str + fmt.Sprintf("%#x", c)
+			continue
+		}
+		str = str + fmt.Sprintf(" %#x", c)
+	}
+	return str
+}

--- a/codec_unmarshal.go
+++ b/codec_unmarshal.go
@@ -1,0 +1,134 @@
+package y3
+
+import (
+	"errors"
+	"reflect"
+)
+
+// []byte to interface, deserialization
+func (codec *Codec) Unmarshal(data []byte, mold *interface{}) error {
+	key := keyOf(codec.Observe)
+	pct, _, err := DecodeNodePacket(data)
+	if err != nil {
+		return err
+	}
+
+	flag, isNode, packet := matchingKey(key, pct)
+	if !flag && []byte("*")[0] != key {
+		return errors.New("not found mold in result")
+	}
+
+	// map to struct
+	err = toMold(packet, isNode, mold)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// TODO: unfinished
+func toMold(packet interface{}, isNode bool, mold *interface{}) error {
+	if isNode == false {
+		primitivePacket := packet.(PrimitivePacket)
+		return unmarshalPrimitivePacket(primitivePacket, mold)
+	}
+
+	// TODO: unfinished
+	//_, _ = mapping.NewDecoder(nil)
+
+	//fmt.Printf("#78 reflect.TypeOf(*output).Kind()=%v\n", reflect.TypeOf(*output).Kind())
+	nodePacket := packet.(NodePacket)
+	if nodePacket.IsArray() && len(nodePacket.PrimitivePackets) > 0 {
+		return unmarshalPrimitivePacketArray(nodePacket.PrimitivePackets, mold)
+	}
+
+	return nil
+}
+
+// convertPrimitivePacketToMold convert PrimitivePacket to Mold
+func unmarshalPrimitivePacket(primitivePacket PrimitivePacket, mold *interface{}) error {
+	switch reflect.TypeOf(*mold).Kind() {
+	case reflect.String:
+		v, err := primitivePacket.ToUTF8String()
+		if err != nil {
+			return err
+		}
+		*mold = v
+	case reflect.Int32:
+		v, err := primitivePacket.ToInt32()
+		if err != nil {
+			return err
+		}
+		*mold = v
+	case reflect.Uint32:
+		v, err := primitivePacket.ToUInt32()
+		if err != nil {
+			return err
+		}
+		*mold = v
+	case reflect.Int64:
+		v, err := primitivePacket.ToInt64()
+		if err != nil {
+			return err
+		}
+		*mold = v
+	case reflect.Uint64:
+		v, err := primitivePacket.ToUInt64()
+		if err != nil {
+			return err
+		}
+		*mold = v
+	case reflect.Float32:
+		v, err := primitivePacket.ToFloat32()
+		if err != nil {
+			return err
+		}
+		*mold = v
+	case reflect.Float64:
+		v, err := primitivePacket.ToFloat64()
+		if err != nil {
+			return err
+		}
+		*mold = v
+	}
+
+	// TODO: unfinished: conv to custom struct
+
+	return nil
+}
+
+// convertPrimitivePacketArrayToMold convert []PrimitivePacket to Mold
+func unmarshalPrimitivePacketArray(primitivePackets []PrimitivePacket, mold *interface{}) error {
+	result := make([]interface{}, 0)
+	switch reflect.TypeOf(*mold).Kind() {
+	case reflect.Array, reflect.Slice:
+		for _, p := range primitivePackets {
+			switch reflect.TypeOf(*mold).Elem().Kind() {
+			case reflect.String:
+				v, _ := p.ToUTF8String()
+				result = append(result, v)
+			case reflect.Int32:
+				v, _ := p.ToInt32()
+				result = append(result, v)
+			case reflect.Uint32:
+				v, _ := p.ToUInt32()
+				result = append(result, v)
+			case reflect.Int64:
+				v, _ := p.ToInt64()
+				result = append(result, v)
+			case reflect.Uint64:
+				v, _ := p.ToUInt64()
+				result = append(result, v)
+			case reflect.Float32:
+				v, _ := p.ToFloat32()
+				result = append(result, v)
+			case reflect.Float64:
+				v, _ := p.ToFloat64()
+				result = append(result, v)
+			}
+		}
+	}
+	*mold = result
+	return nil
+}

--- a/codec_unmarshal_test.go
+++ b/codec_unmarshal_test.go
@@ -1,0 +1,191 @@
+package y3
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/yomorun/yomo-codec-golang/internal/utils"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnmarshal(t *testing.T) {
+	data := []byte{0x81, 0x80, 0x5f, 0x22, 0x1, 0x1, 0x12, 0x1, 0x1,
+		0x13, 0x1, 0x7f, 0x15, 0x1, 0x1, 0x17, 0x2, 0x3e, 0x80, 0x23, 0x1,
+		0x79, 0xa4, 0x34, 0xd4, 0x6, 0x0, 0x1, 0x1, 0x0, 0x1, 0x2, 0xd6, 0x6,
+		0x0, 0x1, 0x1, 0x0, 0x1, 0x2, 0xd8, 0x4, 0x0, 0x2, 0x3e, 0x80, 0xda,
+		0x4, 0x0, 0x2, 0x3f, 0xf0, 0xe5, 0x6, 0x0, 0x1, 0x61, 0x0, 0x1, 0x62,
+		0xd0, 0x6, 0x0, 0x1, 0x1, 0x0, 0x1, 0x2, 0xd1, 0x6, 0x0, 0x1, 0x1, 0x0,
+		0x1, 0x2, 0x19, 0x2, 0x3f, 0xf0, 0xe6, 0x10, 0x80, 0x6, 0x27, 0x1, 0x5,
+		0x28, 0x1, 0x2, 0x80, 0x6, 0x27, 0x1, 0x6, 0x28, 0x1, 0x3}
+
+	testUnmarshalString(t, data, "0x23", "y")
+	testUnmarshalInt32(t, data, "0x22", int32(1))
+	testUnmarshalUint32(t, data, "0x12", uint32(1))
+	testUnmarshalInt64(t, data, "0x13", int64(-1))
+	testUnmarshalUint64(t, data, "0x15", uint64(1))
+	testUnmarshalFloat32(t, data, "0x17", float32(0.25))
+	testUnmarshalFloat64(t, data, "0x19", float64(1))
+
+	testUnmarshalStringArray(t, data, "0x25", []string{"a", "b"})
+	testUnmarshalInt32Array(t, data, "0x10", []int32{1, 2})
+	testUnmarshalUint32Array(t, data, "0x11", []uint32{1, 2})
+	testUnmarshalInt64Array(t, data, "0x14", []int64{1, 2})
+	testUnmarshalUint64Array(t, data, "0x16", []uint64{1, 2})
+	testUnmarshalFloat32Array(t, data, "0x18", []float32{0.25})
+	testUnmarshalFloat64Array(t, data, "0x1a", []float64{1})
+}
+
+func testUnmarshalString(t *testing.T, data []byte, observe string, expected string) {
+	var msg = fmt.Sprintf("testing %s,  %v, (%X)", observe, expected, data)
+	codec := NewCodec(observe)
+	var mold interface{} = ""
+	_ = codec.Unmarshal(data, &mold)
+	assert.Equal(t, expected, mold.(string), msg)
+}
+
+func testUnmarshalInt32(t *testing.T, data []byte, observe string, expected int32) {
+	var msg = fmt.Sprintf("testing %s,  %v, (%X)", observe, expected, data)
+	codec := NewCodec(observe)
+	var mold interface{} = int32(0)
+	_ = codec.Unmarshal(data, &mold)
+	assert.Equal(t, expected, mold.(int32), msg)
+}
+
+func testUnmarshalUint32(t *testing.T, data []byte, observe string, expected uint32) {
+	var msg = fmt.Sprintf("testing %s,  %v, (%X)", observe, expected, data)
+	codec := NewCodec(observe)
+	var mold interface{} = uint32(0)
+	_ = codec.Unmarshal(data, &mold)
+	assert.Equal(t, expected, mold.(uint32), msg)
+}
+
+func testUnmarshalInt64(t *testing.T, data []byte, observe string, expected int64) {
+	var msg = fmt.Sprintf("testing %s,  %v, (%X)", observe, expected, data)
+	codec := NewCodec(observe)
+	var mold interface{} = int64(0)
+	_ = codec.Unmarshal(data, &mold)
+	assert.Equal(t, expected, mold.(int64), msg)
+}
+
+func testUnmarshalUint64(t *testing.T, data []byte, observe string, expected uint64) {
+	var msg = fmt.Sprintf("testing %s,  %v, (%X)", observe, expected, data)
+	codec := NewCodec(observe)
+	var mold interface{} = uint64(0)
+	_ = codec.Unmarshal(data, &mold)
+	assert.Equal(t, expected, mold.(uint64), msg)
+}
+
+func testUnmarshalFloat32(t *testing.T, data []byte, observe string, expected float32) {
+	var msg = fmt.Sprintf("testing %s,  %v, (%X)", observe, expected, data)
+	codec := NewCodec(observe)
+	var mold interface{} = float32(0)
+	_ = codec.Unmarshal(data, &mold)
+	assert.Equal(t, expected, mold.(float32), msg)
+}
+
+func testUnmarshalFloat64(t *testing.T, data []byte, observe string, expected float64) {
+	var msg = fmt.Sprintf("testing %s,  %v, (%X)", observe, expected, data)
+	codec := NewCodec(observe)
+	var mold interface{} = float64(0)
+	_ = codec.Unmarshal(data, &mold)
+	assert.Equal(t, expected, mold.(float64), msg)
+}
+
+func testUnmarshalStringArray(t *testing.T, data []byte, observe string, expected []string) {
+	var msg = fmt.Sprintf("testing %s,  %v, (%X)", observe, expected, data)
+	codec := NewCodec(observe)
+	var mold interface{} = [0]string{}
+	_ = codec.Unmarshal(data, &mold)
+
+	if arr, ok := utils.ToSliceArray(mold); ok {
+		assert.Equal(t, len(expected), len(arr), msg)
+		for i, v := range arr {
+			assert.Equal(t, expected[i], v.(string), msg)
+		}
+	}
+}
+
+func testUnmarshalInt32Array(t *testing.T, data []byte, observe string, expected []int32) {
+	var msg = fmt.Sprintf("testing %s,  %v, (%X)", observe, expected, data)
+	codec := NewCodec(observe)
+	var mold interface{} = [0]int32{}
+	_ = codec.Unmarshal(data, &mold)
+
+	if arr, ok := utils.ToSliceArray(mold); ok {
+		assert.Equal(t, len(expected), len(arr), msg)
+		for i, v := range arr {
+			assert.Equal(t, expected[i], v.(int32), msg)
+		}
+	}
+}
+
+func testUnmarshalUint32Array(t *testing.T, data []byte, observe string, expected []uint32) {
+	var msg = fmt.Sprintf("testing %s,  %v, (%X)", observe, expected, data)
+	codec := NewCodec(observe)
+	var mold interface{} = [0]uint32{}
+	_ = codec.Unmarshal(data, &mold)
+
+	if arr, ok := utils.ToSliceArray(mold); ok {
+		assert.Equal(t, len(expected), len(arr), msg)
+		for i, v := range arr {
+			assert.Equal(t, expected[i], v.(uint32), msg)
+		}
+	}
+}
+
+func testUnmarshalInt64Array(t *testing.T, data []byte, observe string, expected []int64) {
+	var msg = fmt.Sprintf("testing %s,  %v, (%X)", observe, expected, data)
+	codec := NewCodec(observe)
+	var mold interface{} = [0]int64{}
+	_ = codec.Unmarshal(data, &mold)
+
+	if arr, ok := utils.ToSliceArray(mold); ok {
+		assert.Equal(t, len(expected), len(arr), msg)
+		for i, v := range arr {
+			assert.Equal(t, expected[i], v.(int64), msg)
+		}
+	}
+}
+
+func testUnmarshalUint64Array(t *testing.T, data []byte, observe string, expected []uint64) {
+	var msg = fmt.Sprintf("testing %s,  %v, (%X)", observe, expected, data)
+	codec := NewCodec(observe)
+	var mold interface{} = [0]uint64{}
+	_ = codec.Unmarshal(data, &mold)
+
+	if arr, ok := utils.ToSliceArray(mold); ok {
+		assert.Equal(t, len(expected), len(arr), msg)
+		for i, v := range arr {
+			assert.Equal(t, expected[i], v.(uint64), msg)
+		}
+	}
+}
+
+func testUnmarshalFloat32Array(t *testing.T, data []byte, observe string, expected []float32) {
+	var msg = fmt.Sprintf("testing %s,  %v, (%X)", observe, expected, data)
+	codec := NewCodec(observe)
+	var mold interface{} = [0]float32{}
+	_ = codec.Unmarshal(data, &mold)
+
+	if arr, ok := utils.ToSliceArray(mold); ok {
+		assert.Equal(t, len(expected), len(arr), msg)
+		for i, v := range arr {
+			assert.Equal(t, expected[i], v.(float32), msg)
+		}
+	}
+}
+
+func testUnmarshalFloat64Array(t *testing.T, data []byte, observe string, expected []float64) {
+	var msg = fmt.Sprintf("testing %s,  %v, (%X)", observe, expected, data)
+	codec := NewCodec(observe)
+	var mold interface{} = [0]float64{}
+	_ = codec.Unmarshal(data, &mold)
+
+	if arr, ok := utils.ToSliceArray(mold); ok {
+		assert.Equal(t, len(expected), len(arr), msg)
+		for i, v := range arr {
+			assert.Equal(t, expected[i], v.(float64), msg)
+		}
+	}
+}

--- a/encoder.go
+++ b/encoder.go
@@ -54,11 +54,70 @@ func (enc *PirmitivePacketEncoder) SetInt32Value(v int32) {
 	// enc.valbuf.Write(buf)
 }
 
+// SetUInt32Value encode uint32 value
+func (enc *PirmitivePacketEncoder) SetUInt32Value(v uint32) {
+	size := encoding.SizeOfPVarUInt32(v)
+	codec := encoding.VarCodec{Size: size}
+	enc.valbuf = make([]byte, size)
+	err := codec.EncodePVarUInt32(enc.valbuf, v)
+	if err != nil {
+		panic(err)
+	}
+}
+
+// SetInt64Value encode int64 value
+func (enc *PirmitivePacketEncoder) SetInt64Value(v int64) {
+	size := encoding.SizeOfPVarInt64(v)
+	codec := encoding.VarCodec{Size: size}
+	enc.valbuf = make([]byte, size)
+	err := codec.EncodePVarInt64(enc.valbuf, v)
+	if err != nil {
+		panic(err)
+	}
+}
+
+// SetUInt64Value encode uint64 value
+func (enc *PirmitivePacketEncoder) SetUInt64Value(v uint64) {
+	size := encoding.SizeOfPVarUInt64(v)
+	codec := encoding.VarCodec{Size: size}
+	enc.valbuf = make([]byte, size)
+	err := codec.EncodePVarUInt64(enc.valbuf, v)
+	if err != nil {
+		panic(err)
+	}
+}
+
+// SetFloat32Value encode float32 value
+func (enc *PirmitivePacketEncoder) SetFloat32Value(v float32) {
+	var size = encoding.SizeOfVarFloat32(v)
+	codec := encoding.VarCodec{Size: size}
+	enc.valbuf = make([]byte, size)
+	err := codec.EncodeVarFloat32(enc.valbuf, v)
+	if err != nil {
+		panic(err)
+	}
+}
+
+// SetFloat64Value encode float64 value
+func (enc *PirmitivePacketEncoder) SetFloat64Value(v float64) {
+	var size = encoding.SizeOfVarFloat64(v)
+	codec := encoding.VarCodec{Size: size}
+	enc.valbuf = make([]byte, size)
+	err := codec.EncodeVarFloat64(enc.valbuf, v)
+	if err != nil {
+		panic(err)
+	}
+}
+
 // SetStringValue encode string
 func (enc *PirmitivePacketEncoder) SetStringValue(v string) {
 	// buf := []byte(v)
 	// enc.valbuf.Write(buf)
 	enc.valbuf = []byte(v)
+}
+
+func (enc *PirmitivePacketEncoder) SetBytes(buf []byte) {
+	enc.valbuf = buf
 }
 
 // NodePacketEncoder used for encode a node packet
@@ -104,6 +163,10 @@ func (enc *NodePacketEncoder) AddPrimitivePacket(np *PirmitivePacketEncoder) {
 
 func (enc *encoder) addRawPacket(en iEncoder) {
 	enc.valbuf = append(enc.valbuf, en.Encode()...)
+}
+
+func (enc *encoder) AddBytes(buf []byte) {
+	enc.valbuf = append(enc.valbuf, buf...)
 }
 
 // setTag write tag as seqID

--- a/examples/decode.go
+++ b/examples/decode.go
@@ -133,7 +133,7 @@ func encodeArrayPacket() {
 
 	buf := club.Encode()
 	fmt.Printf("obj=%#v\n", obj)
-	fmt.Printf("bars=%#v\n", buf)
+	fmt.Printf("club=%#v\n", buf)
 
 	res, _, _ := y3.DecodeNodePacket(buf)
 	printNodePacket(res)

--- a/internal/utils/common.go
+++ b/internal/utils/common.go
@@ -11,3 +11,6 @@ const DropMSBArrayFlag = 0x3F
 
 // ArrayFlag 描述了`0100 0000`, 用于表示该节点的Value为Slice类型
 const ArrayFlag = 0x40
+
+// KeyOfArrayItem 描述数组项的TLV的sid值
+const KeyOfArrayItem = 0x00

--- a/internal/utils/slice.go
+++ b/internal/utils/slice.go
@@ -1,0 +1,56 @@
+package utils
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+)
+
+func ToSliceArray(arg interface{}) (arr []interface{}, ok bool) {
+	return ToSliceArrayWith(arg, func(value reflect.Value) interface{} {
+		return value.Interface()
+	})
+}
+
+func ToSliceArrayWith(arg interface{}, handle func(value reflect.Value) interface{}) (arr []interface{}, ok bool) {
+	argValue := reflect.ValueOf(arg)
+	if argValue.Type().Kind() == reflect.Slice {
+		length := argValue.Len()
+		if length == 0 {
+			return
+		}
+		ok = true
+		arr = make([]interface{}, length)
+		for i := 0; i < length; i++ {
+			arr[i] = handle(argValue.Index(i))
+		}
+	}
+	return
+}
+
+func ToStringSliceArray(arg interface{}) (out []interface{}, ok bool) {
+	return ToSliceArrayWith(arg, func(value reflect.Value) interface{} {
+		return fmt.Sprintf("%v", value)
+	})
+}
+
+func ToInt64SliceArray(arg interface{}) (out []interface{}, ok bool) {
+	return ToSliceArrayWith(arg, func(value reflect.Value) interface{} {
+		i64, _ := strconv.ParseInt(fmt.Sprintf("%v", value), 10, 64)
+		return i64
+	})
+}
+
+func ToUInt64SliceArray(arg interface{}) (out []interface{}, ok bool) {
+	return ToSliceArrayWith(arg, func(value reflect.Value) interface{} {
+		ui64, _ := strconv.ParseUint(fmt.Sprintf("%v", value), 10, 64)
+		return ui64
+	})
+}
+
+func ToUFloat64SliceArray(arg interface{}) (out []interface{}, ok bool) {
+	return ToSliceArrayWith(arg, func(value reflect.Value) interface{} {
+		f64, _ := strconv.ParseFloat(fmt.Sprintf("%v", value), 64)
+		return f64
+	})
+}

--- a/node_packet.go
+++ b/node_packet.go
@@ -14,3 +14,7 @@ type NodePacket struct {
 func (n *NodePacket) SeqID() byte {
 	return n.basePacket.tag.SeqID()
 }
+
+func (n *NodePacket) IsArray() bool {
+	return n.basePacket.tag.IsArray()
+}

--- a/pkg/varfloat_test.go
+++ b/pkg/varfloat_test.go
@@ -39,7 +39,7 @@ func testVarFloat32(t *testing.T, value float32, bytes []byte) {
 	assert.Equal(t, bytes, buffer, msg)
 
 	var val float32
-	codec = VarCodec{Size:len(bytes)}
+	codec = VarCodec{Size: len(bytes)}
 	assert.Nil(t, codec.DecodeVarFloat32(bytes, &val), msg)
 	assert.Equal(t, value, val, msg)
 }

--- a/primitive_packet.go
+++ b/primitive_packet.go
@@ -45,6 +45,50 @@ func (p *PrimitivePacket) ToUInt32() (uint32, error) {
 	return val, nil
 }
 
+// ToInt64 parse raw as int32 value
+func (p *PrimitivePacket) ToInt64() (int64, error) {
+	var val int64
+	codec := encoding.VarCodec{}
+	err := codec.DecodePVarInt64(p.valbuf, &val)
+	if err != nil {
+		return 0, err
+	}
+	return val, nil
+}
+
+// ToUInt64 parse raw as uint64 value
+func (p *PrimitivePacket) ToUInt64() (uint64, error) {
+	var val uint64
+	codec := encoding.VarCodec{}
+	err := codec.DecodePVarUInt64(p.valbuf, &val)
+	if err != nil {
+		return 0, err
+	}
+	return val, nil
+}
+
+// ToFloat32 parse raw as float32 value
+func (p *PrimitivePacket) ToFloat32() (float32, error) {
+	var val float32
+	codec := encoding.VarCodec{Size: len(p.valbuf)}
+	err := codec.DecodeVarFloat32(p.valbuf, &val)
+	if err != nil {
+		return 0, err
+	}
+	return val, nil
+}
+
+// ToFloat64 parse raw as float64 value
+func (p *PrimitivePacket) ToFloat64() (float64, error) {
+	var val float64
+	codec := encoding.VarCodec{Size: len(p.valbuf)}
+	err := codec.DecodeVarFloat64(p.valbuf, &val)
+	if err != nil {
+		return 0, err
+	}
+	return val, nil
+}
+
 // ToUTF8String parse raw data as string value
 func (p *PrimitivePacket) ToUTF8String() (string, error) {
 	return string(p.valbuf), nil
@@ -81,4 +125,8 @@ func (p *PrimitivePacket) ToPacketArray() (arr []*PrimitivePacket, err error) {
 	}
 
 	return arr, nil
+}
+
+func (p *PrimitivePacket) ToBytes() []byte {
+	return p.valbuf
 }


### PR DESCRIPTION
support primitive type for YoMo to codec:
* string, []string
* int32, []int32
* uint32, []uint32
* int64, []int64
* uint64, []uint64
* float32, []float32
* float64, []float64
closes #14
